### PR TITLE
fix: use default matchAll for empty where filter

### DIFF
--- a/lib/palantir.js
+++ b/lib/palantir.js
@@ -120,7 +120,7 @@ PalantirConnector.prototype.all = function(modelName, filter, options, callback)
     const url = PALANTIR_PATHS.objectSearch;
     const body = {
       objectTypes: [this.settings.objectType],
-      filter: this.buildWhere(modelName, filter.where),
+      filter: this.buildWhere(modelName, filter.where)
     };
 
     const properties = this.buildFields(modelName, filter.fields);

--- a/lib/palantir.js
+++ b/lib/palantir.js
@@ -118,10 +118,11 @@ PalantirConnector.prototype.all = function(modelName, filter, options, callback)
       });
   } else { // search objects by filter
     const url = PALANTIR_PATHS.objectSearch;
-    const body = {objectTypes: [this.settings.objectType]};
-    if (filter.where) {
-      body.filter = this.buildWhere(modelName, filter.where);
-    }
+    const body = {
+      objectTypes: [this.settings.objectType],
+      filter: this.buildWhere(modelName, filter.where),
+    };
+
     const properties = this.buildFields(modelName, filter.fields);
     if (!_.isEmpty(properties)) {
       body.propertySelector = {propertyWhitelist: properties};


### PR DESCRIPTION
* Use default matchAll filter from buildWhere for empty/null where filter 
