### PR TITLE
feat: add objectTypeId to options - PMTA9-225

### DIFF
--- a/lib/palantir.js
+++ b/lib/palantir.js
@@ -67,10 +67,14 @@ PalantirConnector.prototype.create = function(modelName, data, options, callback
   const pkPropertyName = this.getPrimaryKey(modelName);
   const uniquePropName = this.getUniquePropertyName(modelName);
   const pkPropertyValue = md5(standardizeName(data[uniquePropName]));
-  const palantirProperties = Object.assign(this.toPalantirProperties(modelName, data), {policy: this.settings.policy});
+  const props = this.toPalantirProperties(modelName, data);  
+  const palantirProperties = options.noPolicy ? props : Object.assign(
+    props,
+    {policy: this.settings.policy},
+  );
   const body = {
     locator: {
-      typeId: this.settings.objectType,
+      typeId: options.objectTypeId || this.settings.objectType,
       primaryKey: {
         [pkPropertyName]: pkPropertyValue
       }
@@ -101,7 +105,7 @@ PalantirConnector.prototype.all = function(modelName, filter, options, callback)
     debug('get object by id');
     const pkPropertyName = this.getPrimaryKey(modelName);
     const body = {
-      typeId: this.settings.objectType,
+      typeId: options.objectTypeId || this.settings.objectType,
       primaryKey: {
         [pkPropertyName]: id
       }
@@ -120,7 +124,7 @@ PalantirConnector.prototype.all = function(modelName, filter, options, callback)
     const pageSize = options && options.pageSize >= 0 ? options.pageSize : 10000;
     const url = `${PALANTIR_PATHS.objectSearch}?pageSize=${pageSize}`;
     const body = {
-      objectTypes: [this.settings.objectType],
+      objectTypes: [options.objectTypeId || this.settings.objectType],
       filter: this.buildWhere(modelName, filter.where)
     };
 
@@ -158,7 +162,7 @@ PalantirConnector.prototype.count = function count(
   callback
 ) {
   debug('count', modelName, where);
-  const body = {objectTypes: [this.settings.objectType]};
+  const body = {objectTypes: [options.objectTypeId || this.settings.objectType]};
   body.filter = this.buildWhere(modelName, where);
   const url = `${PALANTIR_PATHS.objectSearch}?pageSize=0`;
   debug('request: ', 'POST', url, body);
@@ -184,7 +188,7 @@ PalantirConnector.prototype.destroyAll = function(modelName, where, options, cal
   if (id) {
     const body = {
       locator: {
-        typeId: this.settings.objectType,
+        typeId: options.objectTypeId || this.settings.objectType,
         primaryKey: {
           [pkPropertyName]: id
         }
@@ -197,8 +201,8 @@ PalantirConnector.prototype.destroyAll = function(modelName, where, options, cal
       }
     };
     axios.post(PALANTIR_PATHS.objectLocator, body)
-      .then((response) => {
-        callback();
+      .then(() => {
+        callback(null, {count: 1});
       })
       .catch(err => {
         callback(err);
@@ -208,7 +212,7 @@ PalantirConnector.prototype.destroyAll = function(modelName, where, options, cal
       const body = _.map(results, (result) => {
         return {
           locator: {
-            typeId: this.settings.objectType,
+            typeId: options.objectTypeId || this.settings.objectType,
             primaryKey: {
               [pkPropertyName]: result.id
             }
@@ -252,7 +256,7 @@ PalantirConnector.prototype.replaceById = function replace(
   const palantirProperties = _.omit(this.toPalantirProperties(modelName, data), pkPropertyName);
   const body = {
     locator: {
-      typeId: this.settings.objectType,
+      typeId: options.objectTypeId || this.settings.objectType,
       primaryKey: {
         [pkPropertyName]: id
       }
@@ -295,7 +299,7 @@ PalantirConnector.prototype.update = PalantirConnector.prototype.updateAll = fun
     const body = _.map(results, (result) => {
       return {
         locator: {
-          typeId: this.settings.objectType,
+          typeId: options.objectTypeId || this.settings.objectType,
           primaryKey: {
             [pkPropertyName]: result.id
           }
@@ -321,10 +325,10 @@ PalantirConnector.prototype.update = PalantirConnector.prototype.updateAll = fun
 };
 
 function standardizeName(name) {
-  return name.toLowerCase()
-    .replace('ncgca', '')
-    .trim()
-    .replace(/ /g, '_');
+  return _.toString(name).toLowerCase()
+  .replace('ncgca', '')
+  .trim()
+  .replace(/ /g, '_');
 }
 
 /*!

--- a/lib/palantir.js
+++ b/lib/palantir.js
@@ -67,10 +67,10 @@ PalantirConnector.prototype.create = function(modelName, data, options, callback
   const pkPropertyName = this.getPrimaryKey(modelName);
   const uniquePropName = this.getUniquePropertyName(modelName);
   const pkPropertyValue = md5(standardizeName(data[uniquePropName]));
-  const props = this.toPalantirProperties(modelName, data);  
+  const props = this.toPalantirProperties(modelName, data);
   const palantirProperties = options.noPolicy ? props : Object.assign(
     props,
-    {policy: this.settings.policy},
+    {policy: this.settings.policy}
   );
   const body = {
     locator: {
@@ -326,9 +326,9 @@ PalantirConnector.prototype.update = PalantirConnector.prototype.updateAll = fun
 
 function standardizeName(name) {
   return _.toString(name).toLowerCase()
-  .replace('ncgca', '')
-  .trim()
-  .replace(/ /g, '_');
+    .replace('ncgca', '')
+    .trim()
+    .replace(/ /g, '_');
 }
 
 /*!

--- a/test/fixtures/nock-fixtures/palantir-connector.json
+++ b/test/fixtures/nock-fixtures/palantir-connector.json
@@ -16,6 +16,68 @@
                     "type": "objectAdded",
                     "objectAdded": {
                         "properties": {
+                            "project": "Test-Project-13",
+                            "team": "Connector Test Team",
+                            "project_id": 7890,
+                            "policy": "NCATS"
+                        }
+                    }
+                }
+            }
+        },
+        "status": 200,
+        "response": "ri.phonograph2-objects.main.object.4b8caf66-bc78-4a39-ba6d-982737bdaf65",
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 30 Jul 2020 20:40:28 GMT",
+            "Content-Type",
+            "application/json",
+            "Content-Length",
+            "73",
+            "Connection",
+            "close",
+            "X-B3-TraceId",
+            "43faf597cf6642c6",
+            "X-Xss-Protection",
+            "1; mode=block",
+            "Node-Selection-Strategy",
+            "BALANCED",
+            "X-Frame-Options",
+            "sameorigin",
+            "Referrer-Policy",
+            "strict-origin-when-cross-origin",
+            "Server-Timing",
+            "server;dur=254",
+            "Content-Security-Policy",
+            "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; frame-ancestors 'self';",
+            "X-Content-Type-Options",
+            "nosniff",
+            "Strict-Transport-Security",
+            "max-age=15768000; includeSubDomains",
+            "Referrer-Policy",
+            "strict-origin-when-cross-origin"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://nidap.nih.gov:443",
+        "method": "POST",
+        "path": "/phonograph2/api/storage/edits/events/objectLocator",
+        "body": {
+            "locator": {
+                "typeId": "hts-projects-axle",
+                "primaryKey": {
+                    "project_uid": "03ddab875efe56b6f8ad0ad7d44f1f0b"
+                }
+            },
+            "request": {
+                "customMetadata": {},
+                "payload": {
+                    "type": "objectAdded",
+                    "objectAdded": {
+                        "properties": {
                             "project": "Test-Project-12",
                             "team": "Connector Test Team",
                             "project_id": 3456,

--- a/test/palantir-connector.test.js
+++ b/test/palantir-connector.test.js
@@ -42,6 +42,14 @@ describe('Palantir connector tests', () => {
     await delay(2000);
   });
 
+  it('should create objects with noPolicy option set', async () => {
+    const result = await Project.create(testProjects, {noPolicy: true});
+    expect(result).to.be.an('array').that.is.not.empty;
+    projectId = result[0].id;
+    expect(projectId).to.not.be.empty;
+    await delay(2000);
+  });
+
   it('should get object back', async () => {
     const expectedResult = Object.assign({}, testProjects[0], {
       id: projectId,

--- a/test/palantir-connector.test.js
+++ b/test/palantir-connector.test.js
@@ -16,7 +16,13 @@ describe('Palantir connector tests', () => {
     title: 'Test-Project-12',
     team: 'Connector Test Team',
     projectId: 3456
-  }];
+  },
+  {
+    title: 'Test-Project-13',
+    team: 'Connector Test Team',
+    projectId: 7890
+  },
+];
 
   before(() => {
     const ds = global.getDataSource();


### PR DESCRIPTION
* Adds objectTypeId to options so CRUD methods can operate on different tables in Palantir
* Adds noPolicy option 
* Uses toString in standardizeName method 